### PR TITLE
allowing timeout to be passed in as a parameter

### DIFF
--- a/scripts/connection-tester.js
+++ b/scripts/connection-tester.js
@@ -4,11 +4,10 @@ var net = require('net');
 
 var socket = new net.Socket(),
     host = process.argv[2],
-    port = process.argv[3];
+    port = process.argv[3],
+    connectTimeout = process.argv[4];
 
-var SOCKET_TIMEOUT = 500;   //Setting 500ms as max acceptable timeout
-
-socket.setTimeout(SOCKET_TIMEOUT);
+socket.setTimeout(connectTimeout);
 socket.connect(port, host);
 
 //if able to establish the connection, returns `true`


### PR DESCRIPTION
- will fix the test cases after this is acccepted to remove the deprecated
