### PR TITLE
Two small changes

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,12 +19,18 @@ function testSync(host, port, connectTimeout) {
         success: false,
         error: null
     };
-    if (shellOut && shellOut.code === 0) {
-        if (shellOut.output === 'true') {
-            output.success = true;
+    if (shellOut) {
+        if (shellOut.code === 0) {
+            if (shellOut.output === 'true') {
+                output.success = true;
+            } else {
+                output.error = shellOut.output;
+            }
         } else {
             output.error = shellOut.output;
         }
+    } else {
+        output.error = "No output from connection test";
     }
     return output;
 }

--- a/scripts/connection-tester.js
+++ b/scripts/connection-tester.js
@@ -4,8 +4,8 @@ var net = require('net');
 
 var socket = new net.Socket(),
     host = process.argv[2],
-    port = process.argv[3],
-    connectTimeout = process.argv[4];
+    port = parseInt(process.argv[3], 10),
+    connectTimeout = parseInt(process.argv[4], 10);
 
 socket.setTimeout(connectTimeout);
 socket.connect(port, host);


### PR DESCRIPTION
Fix for newer node version throwing TypeError.  parseInt on numeric parameters passed to connection-tester:

``` sh
node -v && node node_modules/connection-tester/scripts/connection-tester.js 127.0.0.1 22 500
v0.10.45
true

/opt/node-v4.4.7-linux-x64/bin/node node_modules/connection-tester/scripts/connection-tester.js 127.0.0.1 22 500
timers.js:152
    throw new TypeError('msecs must be a number');
    ^

TypeError: msecs must be a number
    at Object.exports.enroll (timers.js:152:11)
    at Socket.setTimeout (net.js:320:12)
    at Object.<anonymous> (/root/node_modules/connection-tester/scripts/connection-tester.js:12:8)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
```

after fix:

``` sh
node -v && node node_modules/connection-tester/scripts/connection-tester.js 127.0.0.1 22 500
v0.10.45
true

/opt/node-v4.4.7-linux-x64/bin/node node_modules/connection-tester/scripts/connection-tester.js 127.0.0.1 22 500
true
```

In testSync, return an error whenever success will be false.

before fix return is:

``` js
{success: false, error: null}
```

after fix return is:

``` js
{ success: false,
  error: 'timers.js:152\n    throw new TypeError(\'msecs must be a number\');\n    ^\n\nTypeError: msecs must be a number\n    at Object.exports.enroll (timers.js:152:11)\n    at Socket.setTimeout (net.js:314:12)\n    at Object.<anonymous> (/Users/mgm/src/node_modules/connection-tester/scripts/connection-tester.js:11:8)\n    at Module._compile (module.js:409:26)\n    at Object.Module._extensions..js (module.js:416:10)\n    at Module.load (module.js:343:32)\n    at Function.Module._load (module.js:300:12)\n    at Function.Module.runMain (module.js:441:10)\n    at startup (node.js:139:18)\n    at node.js:968:3\n' }

{ success: false, error: 'socket TIMEOUT' }

{ success: false,
  error: 'connect ECONNREFUSED 127.0.0.1:80' }
```
